### PR TITLE
Task3 hackaton

### DIFF
--- a/src/components/app.js
+++ b/src/components/app.js
@@ -7,6 +7,7 @@ import Launch from "./launch";
 import Home from "./home";
 import LaunchPads from "./launch-pads";
 import LaunchPad from "./launch-pad";
+import History from "./history";
 
 export default function App() {
   const [faveLaunches, setFaveLaunches] = useState([]);
@@ -68,6 +69,7 @@ export default function App() {
             />
           }
         />
+        <Route path="/spacex-history" element={<History />} />
       </Routes>
     </div>
   );

--- a/src/components/history-card.js
+++ b/src/components/history-card.js
@@ -1,6 +1,8 @@
 import React from "react";
 import { Box, Text, Button } from "@chakra-ui/core";
 
+import { formatDateTime } from "../utils/format-date";
+
 export default function HistoryCard({ data }) {
   const redirectHandler = (link) => {
     window.location.href = link;
@@ -21,10 +23,12 @@ export default function HistoryCard({ data }) {
         letterSpacing="wide"
         fontSize="lg"
         textTransform="uppercase"
-        ml="2"
         width="100%"
       >
         {data.title}
+      </Box>
+      <Box mt="1" fontWeight="semibold" as="h4" lineHeight="tight" isTruncated>
+        {formatDateTime(data.event_date_utc)}
       </Box>
       <Text color="gray.700" fontSize={["md", null, "lg"]} my="8">
         {data.details}

--- a/src/components/history-card.js
+++ b/src/components/history-card.js
@@ -1,0 +1,58 @@
+import React from "react";
+import { Box, Text, Button } from "@chakra-ui/core";
+
+export default function HistoryCard({ data }) {
+  const redirectHandler = (link) => {
+    window.location.href = link;
+  };
+  return (
+    <Box
+      boxShadow="md"
+      borderWidth="1px"
+      rounded="lg"
+      overflow="hidden"
+      m="0 auto"
+      width="50%"
+      p={6}
+    >
+      <Box
+        color="gray.500"
+        fontWeight="semibold"
+        letterSpacing="wide"
+        fontSize="lg"
+        textTransform="uppercase"
+        ml="2"
+        width="100%"
+      >
+        {data.title}
+      </Box>
+      <Text color="gray.700" fontSize={["md", null, "lg"]} my="8">
+        {data.details}
+      </Text>
+      <Box
+        display="flex"
+        direction="row"
+        alignItems="center"
+        justifyContent="flex-start"
+      >
+        <Text>Links: </Text>
+        {Object.keys(data.links).map((key) => {
+          if (data.links[key]) {
+            return (
+              <Button
+                ml="1rem"
+                onClick={() => redirectHandler(data.links[key])}
+                rounded="md"
+                bg="tomato"
+                color="white"
+              >
+                {key[0].toUpperCase() + key.slice(1, key.length)}
+              </Button>
+            );
+          }
+          return null;
+        })}
+      </Box>
+    </Box>
+  );
+}

--- a/src/components/history.js
+++ b/src/components/history.js
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from "react";
+import { Flex, Box, IconButton, Progress, Icon } from "@chakra-ui/core";
+
+import { useSpaceX } from "../utils/use-space-x";
+
+export default function History() {
+  const [countItem, setCountItem] = useState(0);
+  const { data, error, isValidating, setSize, size } = useSpaceX(
+    "/history",
+    {}
+  );
+  console.log(data, error);
+
+  useEffect(() => {
+    localStorage.setItem("history_item", countItem.toString());
+  }, []);
+
+  const changeItem = (direction) => {
+    if (direction === "up" && countItem < data.length) {
+      setCountItem((countItem) => countItem + 1);
+    } else if (direction === "down" && countItem > 0) {
+      setCountItem((countItem) => countItem - 1);
+    }
+    return;
+  };
+
+  if (!data) {
+    return <div>Loading</div>;
+  }
+
+  return (
+    <Box
+      display="flex"
+      flexDirection="row"
+      justifyContent="center"
+      alignItems="center"
+      height="2rem"
+      padding="2rem"
+    >
+      <IconButton
+        icon="arrow-left"
+        width="10%"
+        variant="ghost"
+        onClick={() => changeItem("down")}
+        isDisabled={countItem === 0}
+      />
+      <Progress
+        value={((countItem + 1) / data.length) * 100}
+        size="lg"
+        width="100%"
+      />
+      <IconButton
+        icon="arrow-right"
+        width="10%"
+        variant="ghost"
+        onClick={() => changeItem("up")}
+        isDisabled={countItem === data.length - 1}
+      />
+    </Box>
+  );
+
+  //   return (
+  //     <Flex direction="column" align="center" justify="center">
+  //       <Box>{JSON.stringify(data[countItem])}</Box>
+  //       <Flex
+  //         direction="row"
+  //         align="center"
+  //         justify="space-between"
+  //         width="100vw"
+  //         // height="300px"
+  //       >
+  //         {/* <IconButton></IconButton> */}
+  //         <Progress value={60} bg="red" color="green"/>
+  //         {/* <IconButton></IconButton> */}
+  //       </Flex>
+  //     </Flex>
+  //   );
+}

--- a/src/components/history.js
+++ b/src/components/history.js
@@ -14,8 +14,13 @@ export default function History() {
   console.log(data, error);
 
   useEffect(() => {
-    localStorage.setItem("history_item", countItem.toString());
+    const index = JSON.parse(localStorage.getItem("index-history"));
+    setCountItem(index);
   }, []);
+
+  useEffect(() => {
+    localStorage.setItem("index-history", countItem);
+  }, [countItem]);
 
   const changeItem = (direction) => {
     if (direction === "up" && countItem < data.length) {

--- a/src/components/history.js
+++ b/src/components/history.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { Button, Box } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
 import Timeline from "./timeline";
@@ -31,15 +32,29 @@ export default function History() {
     return;
   };
 
+  const reset = () => {
+    setCountItem(0);
+  };
+
   if (!data) {
     return <div>Loading</div>;
   }
 
   return (
     <>
-      <Breadcrumbs
-        items={[{ label: "Home", to: "/" }, { label: "SpaceX History" }]}
-      />
+      <Box d="flex" justifyContent="space-between" alignItems="center">
+        <Breadcrumbs
+          items={[{ label: "Home", to: "/" }, { label: "SpaceX History" }]}
+        />
+        <Button
+          variantColor="teal"
+          onClick={reset}
+          mr="1.5rem"
+          isDisabled={countItem === 0}
+        >
+          Go back to the start
+        </Button>
+      </Box>
       <Timeline countItem={countItem} changeItem={changeItem} data={data} />
       <HistoryCard data={data[countItem]} />
     </>

--- a/src/components/history.js
+++ b/src/components/history.js
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from "react";
-import { Flex, Box, IconButton, Progress, Icon } from "@chakra-ui/core";
 
 import { useSpaceX } from "../utils/use-space-x";
+import Timeline from "./timeline";
+import HistoryCard from "./history-card";
+import Breadcrumbs from "./breadcrumbs";
 
 export default function History() {
   const [countItem, setCountItem] = useState(0);
@@ -29,50 +31,12 @@ export default function History() {
   }
 
   return (
-    <Box
-      display="flex"
-      flexDirection="row"
-      justifyContent="center"
-      alignItems="center"
-      height="2rem"
-      padding="2rem"
-    >
-      <IconButton
-        icon="arrow-left"
-        width="10%"
-        variant="ghost"
-        onClick={() => changeItem("down")}
-        isDisabled={countItem === 0}
+    <>
+      <Breadcrumbs
+        items={[{ label: "Home", to: "/" }, { label: "SpaceX History" }]}
       />
-      <Progress
-        value={((countItem + 1) / data.length) * 100}
-        size="lg"
-        width="100%"
-      />
-      <IconButton
-        icon="arrow-right"
-        width="10%"
-        variant="ghost"
-        onClick={() => changeItem("up")}
-        isDisabled={countItem === data.length - 1}
-      />
-    </Box>
+      <Timeline countItem={countItem} changeItem={changeItem} data={data} />
+      <HistoryCard data={data[countItem]} />
+    </>
   );
-
-  //   return (
-  //     <Flex direction="column" align="center" justify="center">
-  //       <Box>{JSON.stringify(data[countItem])}</Box>
-  //       <Flex
-  //         direction="row"
-  //         align="center"
-  //         justify="space-between"
-  //         width="100vw"
-  //         // height="300px"
-  //       >
-  //         {/* <IconButton></IconButton> */}
-  //         <Progress value={60} bg="red" color="green"/>
-  //         {/* <IconButton></IconButton> */}
-  //       </Flex>
-  //     </Flex>
-  //   );
 }

--- a/src/components/home.js
+++ b/src/components/home.js
@@ -8,6 +8,7 @@ export default function Home() {
     <Stack m="6" spacing="6">
       <PageLink url="/launches">Browse SpaceX Launches</PageLink>
       <PageLink url="/launch-pads">Browse SpaceX Launch Pads</PageLink>
+      <PageLink url="/spacex-history">Crash course on SpaceX history</PageLink>
     </Stack>
   );
 }

--- a/src/components/timeline.js
+++ b/src/components/timeline.js
@@ -1,0 +1,45 @@
+import React from "react";
+import { Box, IconButton, Progress } from "@chakra-ui/core";
+
+export default function Timeline({ countItem, changeItem, data }) {
+  return (
+    <Box
+      display="flex"
+      flexDirection="row"
+      justifyContent="center"
+      alignItems="center"
+      height="2rem"
+      padding="2rem"
+    >
+      <IconButton
+        icon="arrow-left"
+        width="10%"
+        variant="ghost"
+        onClick={() => changeItem("down")}
+        isDisabled={countItem === 0}
+        variantColor="white"
+        outline="none"
+        _focus={{
+          boxShadow: "none",
+        }}
+      />
+      <Progress
+        value={(countItem / (data.length - 1)) * 100}
+        size="sm"
+        width="100%"
+      />
+      <IconButton
+        icon="arrow-right"
+        width="10%"
+        variant="ghost"
+        onClick={() => changeItem("up")}
+        isDisabled={countItem === data.length - 1}
+        variantColor="white"
+        outline="none"
+        _focus={{
+          boxShadow: "none",
+        }}
+      />
+    </Box>
+  );
+}

--- a/src/components/timeline.js
+++ b/src/components/timeline.js
@@ -1,56 +1,71 @@
 import React from "react";
 import { Box, IconButton, Progress, Tooltip } from "@chakra-ui/core";
-import { Tool } from "react-feather";
 
 export default function Timeline({ countItem, changeItem, data }) {
+  const dateObj = new Date(data[countItem].event_date_utc);
+  const year = dateObj.getFullYear();
   return (
-    <Box
-      display="flex"
-      flexDirection="row"
-      justifyContent="center"
-      alignItems="center"
-      height="2rem"
-      padding="2rem"
-    >
-      <Tooltip
-        label={countItem !== 0 ? "Click to go back in time" : null}
-        placement="bottom"
-      >
-        <IconButton
-          icon="arrow-left"
-          width="10%"
-          variant="ghost"
-          onClick={() => changeItem("down")}
-          isDisabled={countItem === 0}
-          variantColor="white"
-          outline="none"
-          _focus={{
-            boxShadow: "none",
-          }}
-        />
-      </Tooltip>
-      <Progress
-        value={(countItem / (data.length - 1)) * 100}
-        size="sm"
+    <>
+      <Box
+        display="flex"
+        direction="center"
+        justifyContent="center"
+        color="gray.500"
+        fontWeight="semibold"
+        letterSpacing="wide"
+        fontSize="lg"
         width="100%"
-      />
-      <Tooltip
-        label={countItem !== 0 ? "Click to advance in time" : null}
-        placement="bottom"
       >
-        <IconButton
-          icon="arrow-right"
-          width="10%"
-          variant="ghost"
-          onClick={() => changeItem("up")}
-          isDisabled={countItem === data.length - 1}
-          variantColor="white"
-          outline="none"
-          _focus={{
-            boxShadow: "none",
-          }}
+        {year}
+      </Box>
+      <Box
+        display="flex"
+        flexDirection="row"
+        justifyContent="center"
+        alignItems="center"
+        height="2rem"
+        padding="2rem"
+      >
+        <Tooltip
+          label={countItem !== 0 ? "Click to go back in time" : null}
+          placement="bottom"
+        >
+          <IconButton
+            icon="arrow-left"
+            width="10%"
+            variant="ghost"
+            onClick={() => changeItem("down")}
+            isDisabled={countItem === 0}
+            variantColor="white"
+            outline="none"
+            _focus={{
+              boxShadow: "none",
+            }}
+          />
+        </Tooltip>
+        <Progress
+          value={(countItem / (data.length - 1)) * 100}
+          size="sm"
+          width="100%"
         />
-      </Tooltip>
-    </Box>
+        <Tooltip
+          label={countItem !== 0 ? "Click to advance in time" : null}
+          placement="bottom"
+        >
+          <IconButton
+            icon="arrow-right"
+            width="10%"
+            variant="ghost"
+            onClick={() => changeItem("up")}
+            isDisabled={countItem === data.length - 1}
+            variantColor="white"
+            outline="none"
+            _focus={{
+              boxShadow: "none",
+            }}
+          />
+        </Tooltip>
+      </Box>
+    </>
   );
 }

--- a/src/components/timeline.js
+++ b/src/components/timeline.js
@@ -27,7 +27,8 @@ export default function Timeline({ countItem, changeItem, data }) {
         padding="2rem"
       >
         <Tooltip
-          label={countItem !== 0 ? "Click to go back in time" : null}
+          label={countItem !== 0 ? "Click to go back in time" : "You have reached the start"}
+          isDisabled={countItem === 0}
           placement="bottom"
         >
           <IconButton
@@ -49,7 +50,12 @@ export default function Timeline({ countItem, changeItem, data }) {
           width="100%"
         />
         <Tooltip
-          label={countItem !== 0 ? "Click to advance in time" : null}
+          label={
+            countItem < data.length - 1
+              ? "Click to advance in time"
+              : "No more historical events"
+          }
+          isDisabled={countItem === data.length - 1}
           placement="bottom"
         >
           <IconButton

--- a/src/components/timeline.js
+++ b/src/components/timeline.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Box, IconButton, Progress } from "@chakra-ui/core";
+import { Box, IconButton, Progress, Tooltip } from "@chakra-ui/core";
+import { Tool } from "react-feather";
 
 export default function Timeline({ countItem, changeItem, data }) {
   return (
@@ -11,35 +12,45 @@ export default function Timeline({ countItem, changeItem, data }) {
       height="2rem"
       padding="2rem"
     >
-      <IconButton
-        icon="arrow-left"
-        width="10%"
-        variant="ghost"
-        onClick={() => changeItem("down")}
-        isDisabled={countItem === 0}
-        variantColor="white"
-        outline="none"
-        _focus={{
-          boxShadow: "none",
-        }}
-      />
+      <Tooltip
+        label={countItem !== 0 ? "Click to go back in time" : null}
+        placement="bottom"
+      >
+        <IconButton
+          icon="arrow-left"
+          width="10%"
+          variant="ghost"
+          onClick={() => changeItem("down")}
+          isDisabled={countItem === 0}
+          variantColor="white"
+          outline="none"
+          _focus={{
+            boxShadow: "none",
+          }}
+        />
+      </Tooltip>
       <Progress
         value={(countItem / (data.length - 1)) * 100}
         size="sm"
         width="100%"
       />
-      <IconButton
-        icon="arrow-right"
-        width="10%"
-        variant="ghost"
-        onClick={() => changeItem("up")}
-        isDisabled={countItem === data.length - 1}
-        variantColor="white"
-        outline="none"
-        _focus={{
-          boxShadow: "none",
-        }}
-      />
+      <Tooltip
+        label={countItem !== 0 ? "Click to advance in time" : null}
+        placement="bottom"
+      >
+        <IconButton
+          icon="arrow-right"
+          width="10%"
+          variant="ghost"
+          onClick={() => changeItem("up")}
+          isDisabled={countItem === data.length - 1}
+          variantColor="white"
+          outline="none"
+          _focus={{
+            boxShadow: "none",
+          }}
+        />
+      </Tooltip>
     </Box>
   );
 }

--- a/src/components/timeline.js
+++ b/src/components/timeline.js
@@ -27,8 +27,11 @@ export default function Timeline({ countItem, changeItem, data }) {
         padding="2rem"
       >
         <Tooltip
-          label={countItem !== 0 ? "Click to go back in time" : "You have reached the start"}
-          isDisabled={countItem === 0}
+          label={
+            countItem !== 0
+              ? "Click to go back in time"
+              : "You have reached the start"
+          }
           placement="bottom"
         >
           <IconButton
@@ -42,6 +45,7 @@ export default function Timeline({ countItem, changeItem, data }) {
             _focus={{
               boxShadow: "none",
             }}
+            size="sm"
           />
         </Tooltip>
         <Progress
@@ -55,7 +59,6 @@ export default function Timeline({ countItem, changeItem, data }) {
               ? "Click to advance in time"
               : "No more historical events"
           }
-          isDisabled={countItem === data.length - 1}
           placement="bottom"
         >
           <IconButton
@@ -69,6 +72,7 @@ export default function Timeline({ countItem, changeItem, data }) {
             _focus={{
               boxShadow: "none",
             }}
+            size="sm"
           />
         </Tooltip>
       </Box>


### PR DESCRIPTION
## Overview

Reference story #123

- For the hackaton part, I decided to add a section in the app where User can browse over the main historical events in the history of SpaceX. The idea came because I thought User might be interested in knowing a bit more about the milestones that SpaceX has gone through to become this very succesful rocket company that we know today. This is done primarly pulling data from spacexdata.com, History endpoint (https://docs.spacexdata.com/?version=latest#ead57e9b-70db-432d-9923-4bf4b881cfd0). The API returns an array of objects, each containing a specific historical event, and this is displayed to the User in the new app Route: /spacex-history 
- State is persisted across browser sessions thanks to browser local storage, so User can close tab and start again at the historical moment where they left off.

Update Part 1 - Typology of Chakra UI components used

- I wanted to replicate the idea of a timeline that User explores in the App. I settled on the Progress component from Chakra, that allows User to get visual feedback of how long it is by moving through a UX that has several steps. I added a couple of icons so User can click forward and backward, as well as a button to go back to the start as I think User will need to do.
- Information is display in a card, built with a combination of Box and Text components and styling aligned with the rest of the App. Historical events (objects in the array returned by the API) may have up to 3 links (Reddit, Article, Wikipedia), but some have only 2. Hence, I made this part of the card dynamic so it only displays a button to the external link if there is a URL attached to the value of the property.

Update Part 2 - state management

- Data is pulled from API in the history.js component. From here data is passed to the timeline component (displays the progress and the buttons to move back and forth) and the card.
- Since data is an array, a number of things take place when User is looking at the first or last item (i.e. either button back or forth are disabled and the tooltip shows different message).
- Upon mounting component, sync is done with local storage and state is set if Local storage historical item is not 0.

Update Part 3 - Ideas about future development

- Since historical moment objects have no images associated to it, an image could be scrapped from either of the external links that come with it.
- User could move back and forth with the arrows if they wish not to use the mouse and click on the icons.
- Parse the description of the historical moment and link to the page of the launch that is being referenced i.e. Falcon 1 

How to test

Head to Home page and click on new 3rd link. This will bring you to /spacex-history. Notice that upon first time landing there button to go back will be disabled because first item is being displayed. Click forth and back to see card content changing and progress bar showing progress. Click on top right corner "Go back to start" to display first item. Close broswer when not in first item, reopen and notice how page shows last visited item.