### PR TITLE
Fix bug where timeline component was not mounting because countItem w…

### DIFF
--- a/src/components/history.js
+++ b/src/components/history.js
@@ -13,7 +13,11 @@ export default function History() {
 
   useEffect(() => {
     const index = JSON.parse(localStorage.getItem("index-history"));
-    setCountItem(index);
+    if (!index) {
+      setCountItem(0);
+    } else {
+      setCountItem(index);
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
Bug

First useEffect in history.js was pulling item id from local storage. In instances where User had not previously visited the page, no such local storage item existed hence setCountItem was setting 'null' in the state. As a result, first component to load (Timeline was failing, throwing an error in the Browser)

Fix

Added a conditional statement whereas if item pulled from localstorage is null, item id defaults to 0 (lines 16 - 20 in history.js)

Test

Tested browser behaviour 